### PR TITLE
Replace the deprecated method used to navigate to another view

### DIFF
--- a/src/main/java/io/jmix/bookstore/view/customer/CustomerListView.java
+++ b/src/main/java/io/jmix/bookstore/view/customer/CustomerListView.java
@@ -35,7 +35,7 @@ public class CustomerListView extends StandardListView<Customer> {
 
         vectorSource.addGeoObjectClickListener(clickEvent -> {
             Customer customer = clickEvent.getItem();
-            viewNavigators.detailView(Customer.class)
+            viewNavigators.detailView(this, Customer.class)
                     .editEntity(customer)
                     .navigate();
         });


### PR DESCRIPTION
When i run the projet i got this warning :
```java
warning: [removal] <E>detailView(Class<E>) in ViewNavigators has been deprecated and marked for removal
            viewNavigators.detailView(Customer.class)
```