### PR TITLE
Minimal version of pnpm to avoid errors when building the project

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,9 @@ Jmix Bookstore runs using:
 * Spring Boot 3
 * Java 21
 
+In addition, to build the project :
+* pnpm >= 7.0 (`npm install -g pnpm`)
+
 #### Application Size
 
 To give an understanding of the size of the application, here are some rough statistics:


### PR DESCRIPTION
without information in the readme file about the required minimal version of pnpm i got this error :
`Caused by: com.vaadin.flow.server.ExecutionFailedException: Found too old globally installed 'pnpm'. Please upgrade 'pnpm' to at least 7.0.0`

To avoid for next people to get the same error, i created this PR.