### PR TITLE
Ignore new generated files by pnpm

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,5 +26,9 @@ frontend/generated/
 pnpmfile.js
 vite.generated.ts
 webpack.generated.js
+tsconfig.json
+pnpm-lock.yaml
+.flow-node-tasks.lock
+.npmrc
 
 .DS_Store


### PR DESCRIPTION
When building the project, pnpm generate new files that are only needed in the build phase :
```
tsconfig.json
pnpm-lock.yaml
.flow-node-tasks.lock
.npmrc
```