### PR TITLE
Fix PWA icons generation failure on CI

### DIFF
--- a/.github/workflows/ci-pipeline.yml
+++ b/.github/workflows/ci-pipeline.yml
@@ -25,7 +25,7 @@ jobs:
         env:
           PREMIUM_REPO_USER: ${{ secrets.PREMIUM_REPO_USER }}
           PREMIUM_REPO_PASS: ${{ secrets.PREMIUM_REPO_PASS }}
-        run: ./gradlew test
+        run: ./gradlew test --stacktrace
 
       - name: Publish Test Report
         uses: mikepenz/action-junit-report@v3
@@ -37,7 +37,7 @@ jobs:
         env:
           PREMIUM_REPO_USER: ${{ secrets.PREMIUM_REPO_USER }}
           PREMIUM_REPO_PASS: ${{ secrets.PREMIUM_REPO_PASS }}
-        run: ./gradlew -Pvaadin.productionMode=true bootJar
+        run: ./gradlew -Pvaadin.productionMode=true bootJar --stacktrace
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v2

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,1 +1,7 @@
 hilla.active=false
+
+# Vaadin generates the full PWA icon set at build time (TaskGeneratePWAIcons),
+# upscaling icons/icon.png into ~33 images. The default 512MB Gradle heap is
+# borderline and the CI production build fails with "PWA icons generation failed".
+# See vaadin/flow#20842.
+org.gradle.jvmargs=-Xmx2g


### PR DESCRIPTION
## Problem

CI's `Build JAR` step fails on the `:vaadinBuildFrontend` task with:

```
com.vaadin.flow.server.frontend.ExecutionFailedException: PWA icons generation failed
```

The `Run tests` step passes — this is **not** a test failure.

## Cause

Jmix 3.0 pulls Vaadin Flow 25.1.7, which generates the full PWA icon set **at build time** (`TaskGeneratePWAIcons`), upscaling the 210×210 `icons/icon.png` into ~33 images (including iOS splash screens up to ~2732×2778). At Gradle's default 512 MB heap this is borderline and only tips over on the GitHub runner — it builds fine locally and in a clean Linux container (Temurin 21, default heap). Known Vaadin issue: [vaadin/flow#20842](https://github.com/vaadin/flow/issues/20842).

## Fix

- `org.gradle.jvmargs=-Xmx2g` in `gradle.properties` (ubuntu-latest has 7 GB RAM).
- `--stacktrace` added to the CI Gradle steps so any future failure surfaces the real cause.

Could not be reproduced locally, so this PR's CI run is the verification.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
